### PR TITLE
Fix spelling error in documentation

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -14,7 +14,7 @@ Modules = [TrainRuns]
 Private = false
 ```
 
-## Privat Functions
+## Private Functions
 
 ```@autodocs
 Modules = [TrainRuns]


### PR DESCRIPTION
_private_ instead of _privat_